### PR TITLE
Fix: use && not || in valid_street? method conditional

### DIFF
--- a/app/facades/geocoder_facade.rb
+++ b/app/facades/geocoder_facade.rb
@@ -35,7 +35,7 @@ class GeocoderFacade
   end
 
   def self.valid_street?(street)
-    !street.include?('[') || street != ''
+    !street.include?('[') && street != ''
   end
 
 end


### PR DESCRIPTION
**Changes made to the codebase:**

- Change || to && in geocoding facade check of valid_street?. Both conditions must not be true in order for the street to be valid so we needed an and in that conditional.

**How was it tested?**

- graphiql

**Type of Change**

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor

**Issues**

- closes #23 

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new bugs

**Emoji of how you feel submitting this PR:**

- Emoji: 
